### PR TITLE
Items are created from templates in json files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [json-c](https://github.com/json-c/json-c) - JSON-C implements a reference counting object model that allows you 
     to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back 
     into the C representation of JSON objects.
+- [sds](https://github.com/antirez/sds) - Simple Dynamic Strings library for C.
 
 ## Build
 

--- a/include/inventory.h
+++ b/include/inventory.h
@@ -1,31 +1,8 @@
 #ifndef INVENTORY_H
 #define INVENTORY_H
 
-#include <stdbool.h>
-
 #include "vec.h"
-#include "sds.h"
-
-typedef enum
-{
-    ITEM_WEAPON
-} ItemCategory;
-
-typedef struct
-{
-    sds name;
-    ItemCategory category;
-    void* item;
-    bool equipped;
-    int id;
-} Item;
-
-typedef struct
-{
-    int dmg;
-} ItemWeapon;
-
-typedef vec_t(Item) vec_item_t;
+#include "item.h"
 
 typedef struct
 {
@@ -38,9 +15,6 @@ void inv_equip_item(Inventory* inv, int item_id);
 void inv_unequip_item(Inventory* inv, int item_id);
 
 Inventory inv_create_inventory();
-Item inv_construct_item(char* name, ItemCategory category, void* subitem);
-Item* inv_construct_add_item(Inventory* inv, char* name, ItemCategory category,
-                             void* subitem);
 void inv_add_item(Inventory* inv, Item* item);
 
 #endif  // INVENTORY_H

--- a/include/item.h
+++ b/include/item.h
@@ -1,0 +1,33 @@
+#ifndef ITEM_H
+#define ITEM_H
+
+#include <stdbool.h>
+#include "sds.h"
+#include "vec.h"
+
+typedef enum
+{
+    ITEM_WEAPON,
+    ITEM_EMPTY,
+} ItemCategory;
+
+typedef struct
+{
+    sds name;
+    ItemCategory category;
+    void* item;
+    bool equipped;
+    int id;
+} Item;
+
+typedef struct
+{
+    int dmg;
+} ItemWeapon;
+
+typedef vec_t(Item) vec_item_t;
+
+void item_load_items();
+Item item_spawn_item(char* name);
+
+#endif  // ITEM_H

--- a/include/serialization.h
+++ b/include/serialization.h
@@ -5,6 +5,7 @@
 #include "actor.h"
 #include "error.h"
 
+Error srz_load_templates(const char* path, vec_item_t* out_templates);
 Error srz_load_map(const char* path, Map* out_map);
 Error srz_load_player(const char* path, Actor* out_actor);
 Error srz_load_enemies(const char* path, vec_actor_t* out_enemies);

--- a/res/items/weapons/dagger.json
+++ b/res/items/weapons/dagger.json
@@ -1,0 +1,7 @@
+{
+    "name": "Dagger",
+    "category": 0,
+    "item": { "dmg": 5},
+    "equipped": false,
+    "id": -1
+}

--- a/res/items/weapons/sword.json
+++ b/res/items/weapons/sword.json
@@ -1,0 +1,7 @@
+{
+    "name": "Sword",
+    "category": 0,
+    "item": { "dmg": 10},
+    "equipped": false,
+    "id": -1
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 target_sources(rlike PRIVATE main.c map.c actor.c vec2.c vec.c
-        event.c gui.c game.c error.c serialization.c pathfinding.c ai.c inventory.c sds.c)
+        event.c gui.c game.c error.c serialization.c pathfinding.c
+         ai.c inventory.c sds.c item.c)

--- a/src/game.c
+++ b/src/game.c
@@ -9,6 +9,7 @@
 #include "SDL_scancode.h"
 #include "actor.h"
 #include "inventory.h"
+#include "item.h"
 #include "symbols.h"
 #include "event.h"
 #include "gui.h"
@@ -79,12 +80,12 @@ static bool load_map()
 
 static void generate_map()
 {
-    ItemWeapon* sword = malloc(sizeof(ItemWeapon));
-    sword->dmg = 10;
-
     Inventory inv = inv_create_inventory();
-    Item* weapon = inv_construct_add_item(&inv, "Sword", ITEM_WEAPON, sword);
-    inv_equip_item(&inv, weapon->id);
+    Item weapon = item_spawn_item("Sword");
+    inv_add_item(&inv, &weapon);
+    inv_equip_item(&inv, weapon.id);
+    weapon = item_spawn_item("Dagger");
+    inv_add_item(&inv, &weapon);
 
     Actor player = {0,   {0, 0}, PLAYER, PLAYER_COLOR, sdsnew("Player"),
                     100, 12,     inv,    true};
@@ -274,6 +275,8 @@ void init()
     g_game.map = malloc(sizeof(Map));
     vec_init(&g_game.map->rooms);
     vec_init(&g_game.map->tiles);
+
+    item_load_items();
 
     if (!load_map())
     {

--- a/src/inventory.c
+++ b/src/inventory.c
@@ -44,25 +44,10 @@ Inventory inv_create_inventory()
     return inv;
 }
 
-Item inv_construct_item(char* name, ItemCategory category, void* subitem)
-{
-    static int id = 0;
-
-    Item item = {sdsnew(name), category, subitem, false, id};
-    id++;
-
-    return item;
-}
-
-Item* inv_construct_add_item(Inventory* inv, char* name, ItemCategory category,
-                             void* subitem)
-{
-    Item item = inv_construct_item(name, category, subitem);
-    vec_push(&inv->items, item);
-    return inv_find_item(inv, item.id);
-}
-
 void inv_add_item(Inventory* inv, Item* item)
 {
+    if (inv_find_item(inv, item->id) != NULL)
+        return;
+
     vec_push(&inv->items, *item);
 }

--- a/src/item.c
+++ b/src/item.c
@@ -1,0 +1,58 @@
+#include "serialization.h"
+#include "vec.h"
+#include "item.h"
+
+static vec_item_t g_item_templates;
+
+static Item spawn_empty_item(int id)
+{
+    return (Item){"EMPTY", ITEM_EMPTY, NULL, false, id};
+}
+
+static Item* find_template(sds name)
+{
+    for (int i = 0; i < g_item_templates.length; i++)
+    {
+        if (memcmp(g_item_templates.data[i].name, name,
+                   sdslen(g_item_templates.data[i].name)) == 0)
+            return &g_item_templates.data[i];
+    }
+    return NULL;
+}
+
+void item_load_items()
+{
+    if (srz_load_templates("res/items/weapons", &g_item_templates) != OK)
+    {
+        fatal(__FILE__, __func__, __LINE__, "failed to load item templates");
+    }
+}
+
+Item item_spawn_item(sds name)
+{
+    static int id = 0;
+
+    Item* template = find_template(name);
+    if (template == NULL)
+    {
+        return spawn_empty_item(id++);
+    }
+
+    void* subitem;
+    switch (template->category)
+    {
+        case ITEM_WEAPON:
+            subitem = malloc(sizeof(ItemWeapon));
+            break;
+        default:
+            fatal(__FILE__, __func__, __LINE__,
+                  "not all item category options were covered.");
+            return spawn_empty_item(id++);
+    }
+    memcpy(subitem, template->item, sizeof(subitem));
+
+    Item item = {sdsdup(template->name), template->category, subitem, false, id};
+    id++;
+
+    return item;
+}

--- a/src/map.c
+++ b/src/map.c
@@ -48,12 +48,10 @@ static void spawn_enemies(Map* map, vec_actor_t* enemies)
         if (enemies_spawned >= map->num_enemies)
             return;
 
-        ItemWeapon* sword = malloc(sizeof(ItemWeapon));
-        sword->dmg = 10;
-
         Inventory inv = inv_create_inventory();
-        Item* weapon = inv_construct_add_item(&inv, "Sword", ITEM_WEAPON, sword);
-        inv_equip_item(&inv, weapon->id);
+        Item weapon = item_spawn_item("Sword");
+        inv_add_item(&inv, &weapon);
+        inv_equip_item(&inv, weapon.id);
 
         sds name = sdscatprintf(sdsempty(), "Enemy%d", enemy_id);
 


### PR DESCRIPTION
- Special item templates can be created as JSON files, that can then be
  used to spawn copies of loaded templates.
- Separated `Item` and `Inventory`.
- Added a new item category `ITEM_EMPTY` that is used when an item
  couldn't be created.
- Update README to include the new dependency.