### PR TITLE
Added items prefixes.

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -12,6 +12,12 @@ typedef enum
     ITEM_EMPTY,
 } ItemCategory;
 
+typedef enum
+{
+    ITEM_PREFIX_FINE,
+    ITEM_PREFIX_NONE
+} ItemPrefix;
+
 typedef struct
 {
     sds name;
@@ -33,7 +39,8 @@ typedef struct
 
 typedef vec_t(Item) vec_item_t;
 
-void item_load_items();
-Item item_spawn_item(char* name);
+void item_init();
+Item item_spawn_item(sds name, int depth);
+void item_end();
 
 #endif  // ITEM_H

--- a/include/map.h
+++ b/include/map.h
@@ -63,7 +63,8 @@ typedef struct
 void map_init();
 // I can't include `actor.h` (it would cause a cyclic dependency),
 // so I have to use void* here.
-Map* map_generate(Vec2* out_rogue_start_pos, void* out_enemies, bool spawn_boss);
+Map* map_generate(Vec2* out_rogue_start_pos, void* out_enemies, bool spawn_boss,
+                  int depth);
 void map_end(Map* map);
 
 void map_update_fog_of_war(Map* map, Vec2 player_pos, int player_vision_radius);

--- a/res/items/armor/leather_armor.json
+++ b/res/items/armor/leather_armor.json
@@ -1,0 +1,9 @@
+{
+    "name": "Leather armor",
+    "id": -1,
+    "category": 1,
+    "item": {
+        "defence": 2
+    },
+    "equipped": true
+}

--- a/src/item.c
+++ b/src/item.c
@@ -1,8 +1,15 @@
+#include "random.h"
 #include "serialization.h"
 #include "vec.h"
 #include "item.h"
 
-static vec_item_t g_item_templates;
+static vec_item_t g_templates;
+// clang-format off
+static int g_prefix_depths[] = {
+    [ITEM_PREFIX_FINE] = 2,
+    [ITEM_PREFIX_NONE] = 1
+};
+// clang-format on
 
 static Item spawn_empty_item(int id)
 {
@@ -11,25 +18,67 @@ static Item spawn_empty_item(int id)
 
 static Item* find_template(sds name)
 {
-    for (int i = 0; i < g_item_templates.length; i++)
+    for (int i = 0; i < g_templates.length; i++)
     {
-        if (memcmp(g_item_templates.data[i].name, name,
-                   sdslen(g_item_templates.data[i].name)) == 0)
-            return &g_item_templates.data[i];
+        if (memcmp(g_templates.data[i].name, name, sdslen(g_templates.data[i].name)) == 0)
+            return &g_templates.data[i];
     }
     return NULL;
 }
 
-void item_load_items()
+static ItemPrefix get_rand_prefix(int depth)
 {
-    if (srz_load_item_templates("res/items/weapons", &g_item_templates) != OK ||
-        srz_load_item_templates("res/items/armor", &g_item_templates) != OK)
+    vec_int_t possible_prefixes;
+    vec_init(&possible_prefixes);
+
+    for (int prefix = 0; prefix <= ITEM_PREFIX_NONE; prefix++)
+    {
+        if (g_prefix_depths[prefix] <= depth)
+            vec_push(&possible_prefixes, prefix);
+    }
+
+    ItemPrefix prefix =
+        (ItemPrefix)
+            possible_prefixes.data[rand_random_int(0, possible_prefixes.length - 1)];
+
+    vec_deinit(&possible_prefixes);
+
+    return prefix;
+}
+
+static void apply_prefix(ItemCategory category, Item* item, ItemPrefix prefix)
+{
+    switch (prefix)
+    {
+        case ITEM_PREFIX_FINE:
+            switch (category)
+            {
+                case ITEM_WEAPON:
+                    ((ItemWeapon*)item->item)->dmg += 2;
+                    break;
+                case ITEM_ARMOR:
+                    ((ItemArmor*)item->item)->defence += 1;
+                    break;
+                case ITEM_EMPTY:
+                    break;
+            }
+            item->name = sdscat(sdsnew("Fine "), item->name);
+            break;
+        case ITEM_PREFIX_NONE:
+            break;
+    }
+}
+
+void item_init()
+{
+    if (srz_load_item_templates("res/items/weapons", &g_templates) != OK ||
+        srz_load_item_templates("res/items/armor", &g_templates) != OK)
     {
         fatal(__FILE__, __func__, __LINE__, "failed to load item templates");
     }
 }
 
-Item item_spawn_item(sds name)
+Item item_spawn_item(sds name, int depth)
 {
     static int id = 0;
 
@@ -56,7 +105,19 @@ Item item_spawn_item(sds name)
     memcpy(subitem, template->item, sizeof(subitem));
 
     Item item = {sdsdup(template->name), template->category, subitem, false, id};
-    id++;
 
+    apply_prefix(template->category, &item, get_rand_prefix(depth));
+
+    id++;
     return item;
+}
+
+void item_end()
+{
+    for (int j = 0; j < g_templates.length; j++)
+    {
+        free(g_templates.data[j].item);
+        sdsfree(g_templates.data[j].name);
+    }
+    vec_deinit(&g_templates);
 }


### PR DESCRIPTION
- Prefixes that are randomly added to items on respective depths.
- The player is not reset when entering the next depth.
- Widened game window.
- Refactored `Actor` freeing into a separate function.
- Memory leak with item templates is fixed.
- New armor.
- Inventory gui frame has dynamic width.
- Clearing background when drawing a frame is now optional.
- Renamed `HP` to `Health`.
- Formatting changes in `map.c`.